### PR TITLE
Minor adjustment to file paths provided in our example manifest files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - ./inputs:/workspace/10test/
 
       # Output files
-      - ./results:/workspace/results/
+      - ./results:/workspace/extraction/results_filtered/
     depends_on:
       grobid:
         condition: service_healthy

--- a/kubernetes/reactionminer.job.yml
+++ b/kubernetes/reactionminer.job.yml
@@ -50,12 +50,12 @@ spec:
         # Inputs
         - mountPath: /workspace/10test
           name: shared-storage
-          subPath: uws/jobs/reactionminer/test3/in
+          subPath: uws/jobs/reactionminer/test/in
 
         # Outputs
         - mountPath: /workspace/extraction/results_filtered
           name: shared-storage
-          subPath: uws/jobs/reactionminer/test3/out
+          subPath: uws/jobs/reactionminer/test/out
 
         # HuggingFace model cache
         - mountPath: /root/.cache/huggingface/hub

--- a/kubernetes/reactionminer.pod.yaml
+++ b/kubernetes/reactionminer.pod.yaml
@@ -51,12 +51,12 @@ spec:
         # Inputs
         - mountPath: /workspace/10test
           name: shared-storage
-          subPath: uws/jobs/reactionminer/test3/in
+          subPath: uws/jobs/reactionminer/test/in
 
         # Outputs
-        - mountPath: /workspace/extraction/results
+        - mountPath: /workspace/extraction/results_filtered
           name: shared-storage
-          subPath: uws/jobs/reactionminer/test3/out
+          subPath: uws/jobs/reactionminer/test/out
 
         # HuggingFace model cache
         - mountPath: /root/.cache/huggingface/hub


### PR DESCRIPTION
## Problem
Both Docker Compose + Kubernetes use some incorrect mount paths for outputting the post-processed JSON files

## Approach
* fix: use correct output path for post-processed JSON files in Docker/Kubernetes

Previously we were mounting our NFS share to: `/workspace/extraction/results`
The correct path to use appears to actually be: `/workspace/extraction/results_filtered`