### PR TITLE
feat: added Docker automated build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,7 +29,7 @@ on:
 
 # Certain actions will only run when this is the main repo.
 env:
-  MAIN_REPO: moleculemaker/ReactionMiner
+  MAIN_REPO: maszhongming/ReactionMiner
   DOCKERHUB_ORG: moleculemaker
 
 jobs:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,74 @@
+name: Docker
+
+# This will run when:
+# - when new code is pushed to main/develop to push the tags
+#   latest and develop
+# - when a pull request is created and updated  to make sure the
+#   Dockerfile is still valid.
+# To be able to push to dockerhub, this execpts the following
+# secrets to be set in the project:
+# - DOCKERHUB_USERNAME : username that can push to the org
+# - DOCKERHUB_PASSWORD : password associated with the username
+on:
+  push:
+    branches:
+      - main
+      # TODO: Remove ReactionMiner_v2 once it has been merged back to main
+      - ReactionMiner_v2
+
+  pull_request:
+  
+  # Trigger the workflow on release activity
+  release:
+    # Only use the types keyword to narrow down the activity types that will trigger your workflow.
+    types:
+      - published
+      - edited
+      - created
+
+# Certain actions will only run when this is the main repo.
+env:
+  MAIN_REPO: moleculemaker/ReactionMiner
+  DOCKERHUB_ORG: moleculemaker
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - uses: actions/checkout@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            moleculemaker/reactionminer
+          tags: |
+            # set latest tag for default branch
+            # TODO: Replace check for "latest" once it has been merged back to main
+            # type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest
+            type=ref,event=branch
+            type=ref,event=pr
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,6 @@ on:
       - main
       # TODO: Remove these once it has been merged back to main
       - ReactionMiner_v2
-      - add-docker-workflow
 
   pull_request:
   

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,8 +1,7 @@
 name: Docker
 
 # This will run when:
-# - when new code is pushed to main/develop to push the tags
-#   latest and develop
+# - when new code is pushed to main/ReactionMiner_v2 to push a new "latest" image
 # - when a pull request is created and updated  to make sure the
 #   Dockerfile is still valid.
 # To be able to push to dockerhub, this execpts the following

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,8 +13,9 @@ on:
   push:
     branches:
       - main
-      # TODO: Remove ReactionMiner_v2 once it has been merged back to main
+      # TODO: Remove these once it has been merged back to main
       - ReactionMiner_v2
+      - add-docker-workflow
 
   pull_request:
   
@@ -39,6 +40,8 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - uses: actions/checkout@v3
+        with:
+          submodules: 'true'
 
       - name: Docker meta
         id: meta
@@ -68,7 +71,9 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          # TODO: support arm64?
+          # platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Problem
As the GitHub repo receives updates, rebuilding the Docker image currently requires a manual process to keep updated

We would like to automate this process to prevent the Docker image from falling out-of-sync with the source code

## Approach
* feat: trigger an automated Docker build every time that new commits are pushed to the GitHub repo
    * we are currently watching the following branches: `main`, `ReactionMiner_v2`, `add-docker-workflow` (my test branch)
    * NOTE: once this is merged to `ReactionMiner_v2`, we could remove `add-docker-workflow`
    * NOTE: once `ReactionMiner_v2` is merged back to main, we could remove the others and only watch `main`

We use a similar process for many of our other repositories as well

### Required Setup
~~⚠️ Please **do not** merge this PR until we add these secrets to the settings in your GitHub repo ⚠️~~

UPDATE: These secrets have been added to the ReactionMiner repository

To use this automated build, you will need to create two secrets in your [repository settings](https://github.com/maszhongming/ReactionMiner/settings/secrets/actions):
    * `DOCKERHUB_USERNAME` = my username on DockerHub (an account w/ permissions to push to [moleculemaker/reactionminer](https://hub.docker.com/r/moleculemaker/reactionminer))
    * `DOCKERHUB_PASSWORD` = my password on DockerHub ([personal access token](https://app.docker.com/settings/personal-access-tokens) should work here too)

I can send you these values if you would be willing to add them as Secrets - these will be used during the automated build to push the image to our DockerHub organization after it builds successfully. These could also be added at the GitHub organization level, if your repo is part of an organization

### Viewing Status and Logs
You can see an example of the build logs from the runs resulting from this automated build process here:
https://github.com/moleculemaker/ReactionMiner/actions

This workflow should also run a build for every Pull Request and attach a build status to each one:
* 🟡  - a yellow circle means that the latest build is still in progress
* ✔️ - a green checkmark means that the latest build completed successfully
* ❌ - a red X means that an error was encountered during the latest build

The latest build for each PR will appear under the "Checks" tab in that Pull Request

![Screenshot 2025-01-24 at 10 49 26 AM](https://github.com/user-attachments/assets/4f22e885-4084-43bc-bc19-3366582c5fcb)