### PR TITLE
feat: submit PDF + JSON to ChemScraper after ReactionMiner job

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,9 @@
 HF_TOKEN_PATH=/home/mambauser/.huggingface/token
 GROBID_SERVER=grobid
+
+CHEMSCRAPER_INDEX_NAME='lambert8-test'
+CHEMSCRAPER_PDF_INPUT_DIR='/workspace/10test'
+CHEMSCRAPER_REACTIONMINER_JSON_DIR='/workspace/extraction/results_filtered'
+
+CHEMSCRAPER_BASE_URL='http://chemscraper-service-staging.svc.cluster.local:8000'
+CHEMSCRAPER_OUTPUT_DIR='/workspace/chemscraper-output'

--- a/.env
+++ b/.env
@@ -6,4 +6,4 @@ CHEMSCRAPER_PDF_INPUT_DIR='/workspace/10test'
 CHEMSCRAPER_REACTIONMINER_JSON_DIR='/workspace/extraction/results_filtered'
 
 CHEMSCRAPER_BASE_URL='http://chemscraper-services-staging.svc.cluster.local:8000'
-CHEMSCRAPER_OUTPUT_DIR='/workspace/chemscraper-output'
+CHEMSCRAPER_OUTPUT_DIR='/workspace/extraction/results_filtered'

--- a/.env
+++ b/.env
@@ -5,5 +5,5 @@ CHEMSCRAPER_INDEX_NAME='lambert8-test'
 CHEMSCRAPER_PDF_INPUT_DIR='/workspace/10test'
 CHEMSCRAPER_REACTIONMINER_JSON_DIR='/workspace/extraction/results_filtered'
 
-CHEMSCRAPER_BASE_URL='http://chemscraper-service-staging.svc.cluster.local:8000'
+CHEMSCRAPER_BASE_URL='http://chemscraper-services-staging.svc.cluster.local:8000'
 CHEMSCRAPER_OUTPUT_DIR='/workspace/chemscraper-output'

--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 HF_TOKEN_PATH=/home/mambauser/.huggingface/token
 GROBID_SERVER=grobid
 
-CHEMSCRAPER_INDEX_NAME='lambert8-test'
+CHEMSCRAPER_INDEX_NAME='test'  # any unique string, use this when calling /search
 CHEMSCRAPER_PDF_INPUT_DIR='/workspace/10test'
 CHEMSCRAPER_REACTIONMINER_JSON_DIR='/workspace/extraction/results_filtered'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,8 @@ COPY segmentation ./segmentation
 # pdf2text is needed by extraction for config.py
 COPY pdf2text/config.py ./extraction/config.py
 COPY example.py ./example.py
+COPY run_chemscraper.py ./run_chemscraper.py
+COPY chemscraper ./chemscraper
 
 # Run our docker entrypoint to execute the full workflow
 COPY entrypoint.sh ./entrypoint.sh

--- a/chemscraper/.gitignore
+++ b/chemscraper/.gitignore
@@ -1,0 +1,23 @@
+__pycache__/
+build/
+dist/
+*.egg-info/
+.pytest_cache/
+
+# pyenv
+.python-version
+
+# Environments
+.env
+.venv
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# JetBrains
+.idea/
+
+/coverage.xml
+/.coverage

--- a/chemscraper/README.md
+++ b/chemscraper/README.md
@@ -1,0 +1,124 @@
+# fast-api-client
+A client library for accessing FastAPI
+
+## Usage
+First, create a client:
+
+```python
+from fast_api_client import Client
+
+client = Client(base_url="https://api.example.com")
+```
+
+If the endpoints you're going to hit require authentication, use `AuthenticatedClient` instead:
+
+```python
+from fast_api_client import AuthenticatedClient
+
+client = AuthenticatedClient(base_url="https://api.example.com", token="SuperSecretToken")
+```
+
+Now call your endpoint and use your models:
+
+```python
+from fast_api_client.models import MyDataModel
+from fast_api_client.api.my_tag import get_my_data_model
+from fast_api_client.types import Response
+
+with client as client:
+    my_data: MyDataModel = get_my_data_model.sync(client=client)
+    # or if you need more info (e.g. status_code)
+    response: Response[MyDataModel] = get_my_data_model.sync_detailed(client=client)
+```
+
+Or do the same thing with an async version:
+
+```python
+from fast_api_client.models import MyDataModel
+from fast_api_client.api.my_tag import get_my_data_model
+from fast_api_client.types import Response
+
+async with client as client:
+    my_data: MyDataModel = await get_my_data_model.asyncio(client=client)
+    response: Response[MyDataModel] = await get_my_data_model.asyncio_detailed(client=client)
+```
+
+By default, when you're calling an HTTPS API it will attempt to verify that SSL is working correctly. Using certificate verification is highly recommended most of the time, but sometimes you may need to authenticate to a server (especially an internal server) using a custom certificate bundle.
+
+```python
+client = AuthenticatedClient(
+    base_url="https://internal_api.example.com", 
+    token="SuperSecretToken",
+    verify_ssl="/path/to/certificate_bundle.pem",
+)
+```
+
+You can also disable certificate validation altogether, but beware that **this is a security risk**.
+
+```python
+client = AuthenticatedClient(
+    base_url="https://internal_api.example.com", 
+    token="SuperSecretToken", 
+    verify_ssl=False
+)
+```
+
+Things to know:
+1. Every path/method combo becomes a Python module with four functions:
+    1. `sync`: Blocking request that returns parsed data (if successful) or `None`
+    1. `sync_detailed`: Blocking request that always returns a `Request`, optionally with `parsed` set if the request was successful.
+    1. `asyncio`: Like `sync` but async instead of blocking
+    1. `asyncio_detailed`: Like `sync_detailed` but async instead of blocking
+
+1. All path/query params, and bodies become method arguments.
+1. If your endpoint had any tags on it, the first tag will be used as a module name for the function (my_tag above)
+1. Any endpoint which did not have a tag will be in `fast_api_client.api.default`
+
+## Advanced customizations
+
+There are more settings on the generated `Client` class which let you control more runtime behavior, check out the docstring on that class for more info. You can also customize the underlying `httpx.Client` or `httpx.AsyncClient` (depending on your use-case):
+
+```python
+from fast_api_client import Client
+
+def log_request(request):
+    print(f"Request event hook: {request.method} {request.url} - Waiting for response")
+
+def log_response(response):
+    request = response.request
+    print(f"Response event hook: {request.method} {request.url} - Status {response.status_code}")
+
+client = Client(
+    base_url="https://api.example.com",
+    httpx_args={"event_hooks": {"request": [log_request], "response": [log_response]}},
+)
+
+# Or get the underlying httpx client to modify directly with client.get_httpx_client() or client.get_async_httpx_client()
+```
+
+You can even set the httpx client directly, but beware that this will override any existing settings (e.g., base_url):
+
+```python
+import httpx
+from fast_api_client import Client
+
+client = Client(
+    base_url="https://api.example.com",
+)
+# Note that base_url needs to be re-set, as would any shared cookies, headers, etc.
+client.set_httpx_client(httpx.Client(base_url="https://api.example.com", proxies="http://localhost:8030"))
+```
+
+## Building / publishing this package
+This project uses [Poetry](https://python-poetry.org/) to manage dependencies  and packaging.  Here are the basics:
+1. Update the metadata in pyproject.toml (e.g. authors, version)
+1. If you're using a private repository, configure it with Poetry
+    1. `poetry config repositories.<your-repository-name> <url-to-your-repository>`
+    1. `poetry config http-basic.<your-repository-name> <username> <password>`
+1. Publish the client with `poetry publish --build -r <your-repository-name>` or, if for public PyPI, just `poetry publish --build`
+
+If you want to install this client into another project without publishing it (e.g. for development) then:
+1. If that project **is using Poetry**, you can simply do `poetry add <path-to-this-client>` from that project
+1. If that project is not using Poetry:
+    1. Build a wheel with `poetry build -f wheel`
+    1. Install that wheel from the other project `pip install <path-to-wheel>`

--- a/chemscraper/fast_api_client/__init__.py
+++ b/chemscraper/fast_api_client/__init__.py
@@ -1,0 +1,8 @@
+"""A client library for accessing FastAPI"""
+
+from .client import AuthenticatedClient, Client
+
+__all__ = (
+    "AuthenticatedClient",
+    "Client",
+)

--- a/chemscraper/fast_api_client/api/__init__.py
+++ b/chemscraper/fast_api_client/api/__init__.py
@@ -1,0 +1,1 @@
+"""Contains methods for accessing the API"""

--- a/chemscraper/fast_api_client/api/default/extract_extract_pdf_post.py
+++ b/chemscraper/fast_api_client/api/default/extract_extract_pdf_post.py
@@ -1,0 +1,182 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.body_extract_extract_pdf_post import BodyExtractExtractPdfPost
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    body: BodyExtractExtractPdfPost,
+    generate_svg: Union[Unset, bool] = False,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    params: dict[str, Any] = {}
+
+    params["generate_svg"] = generate_svg
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/extractPdf",
+        "params": params,
+    }
+
+    _body = body.to_multipart()
+
+    _kwargs["files"] = _body
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[Any, HTTPValidationError]]:
+    if response.status_code == 200:
+        response_200 = response.json()
+        return response_200
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Any, HTTPValidationError]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: BodyExtractExtractPdfPost,
+    generate_svg: Union[Unset, bool] = False,
+) -> Response[Union[Any, HTTPValidationError]]:
+    """Extract
+
+    Args:
+        generate_svg (Union[Unset, bool]):  Default: False.
+        body (BodyExtractExtractPdfPost):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, HTTPValidationError]]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        generate_svg=generate_svg,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: BodyExtractExtractPdfPost,
+    generate_svg: Union[Unset, bool] = False,
+) -> Optional[Union[Any, HTTPValidationError]]:
+    """Extract
+
+    Args:
+        generate_svg (Union[Unset, bool]):  Default: False.
+        body (BodyExtractExtractPdfPost):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, HTTPValidationError]
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+        generate_svg=generate_svg,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: BodyExtractExtractPdfPost,
+    generate_svg: Union[Unset, bool] = False,
+) -> Response[Union[Any, HTTPValidationError]]:
+    """Extract
+
+    Args:
+        generate_svg (Union[Unset, bool]):  Default: False.
+        body (BodyExtractExtractPdfPost):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, HTTPValidationError]]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        generate_svg=generate_svg,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: BodyExtractExtractPdfPost,
+    generate_svg: Union[Unset, bool] = False,
+) -> Optional[Union[Any, HTTPValidationError]]:
+    """Extract
+
+    Args:
+        generate_svg (Union[Unset, bool]):  Default: False.
+        body (BodyExtractExtractPdfPost):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, HTTPValidationError]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+            generate_svg=generate_svg,
+        )
+    ).parsed

--- a/chemscraper/fast_api_client/api/default/extract_reaction_miner_matching_post.py
+++ b/chemscraper/fast_api_client/api/default/extract_reaction_miner_matching_post.py
@@ -1,0 +1,182 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.body_extract_reaction_miner_matching_post import BodyExtractReactionMinerMatchingPost
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    body: BodyExtractReactionMinerMatchingPost,
+    generate_svg: Union[Unset, bool] = False,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    params: dict[str, Any] = {}
+
+    params["generate_svg"] = generate_svg
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/reaction_miner_matching",
+        "params": params,
+    }
+
+    _body = body.to_multipart()
+
+    _kwargs["files"] = _body
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[Any, HTTPValidationError]]:
+    if response.status_code == 200:
+        response_200 = response.json()
+        return response_200
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Any, HTTPValidationError]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: BodyExtractReactionMinerMatchingPost,
+    generate_svg: Union[Unset, bool] = False,
+) -> Response[Union[Any, HTTPValidationError]]:
+    """Extract
+
+    Args:
+        generate_svg (Union[Unset, bool]):  Default: False.
+        body (BodyExtractReactionMinerMatchingPost):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, HTTPValidationError]]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        generate_svg=generate_svg,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: BodyExtractReactionMinerMatchingPost,
+    generate_svg: Union[Unset, bool] = False,
+) -> Optional[Union[Any, HTTPValidationError]]:
+    """Extract
+
+    Args:
+        generate_svg (Union[Unset, bool]):  Default: False.
+        body (BodyExtractReactionMinerMatchingPost):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, HTTPValidationError]
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+        generate_svg=generate_svg,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: BodyExtractReactionMinerMatchingPost,
+    generate_svg: Union[Unset, bool] = False,
+) -> Response[Union[Any, HTTPValidationError]]:
+    """Extract
+
+    Args:
+        generate_svg (Union[Unset, bool]):  Default: False.
+        body (BodyExtractReactionMinerMatchingPost):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, HTTPValidationError]]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        generate_svg=generate_svg,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: BodyExtractReactionMinerMatchingPost,
+    generate_svg: Union[Unset, bool] = False,
+) -> Optional[Union[Any, HTTPValidationError]]:
+    """Extract
+
+    Args:
+        generate_svg (Union[Unset, bool]):  Default: False.
+        body (BodyExtractReactionMinerMatchingPost):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, HTTPValidationError]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+            generate_svg=generate_svg,
+        )
+    ).parsed

--- a/chemscraper/fast_api_client/api/default/get_version_get_version_get.py
+++ b/chemscraper/fast_api_client/api/default/get_version_get_version_get.py
@@ -1,0 +1,79 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...types import Response
+
+
+def _get_kwargs() -> dict[str, Any]:
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/get_version",
+    }
+
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Any]:
+    if response.status_code == 200:
+        return None
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Any]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Response[Any]:
+    """Get Version
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Response[Any]:
+    """Get Version
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Any]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)

--- a/chemscraper/fast_api_client/api/default/index_pdfs_reactions_batch_index_pdfs_reactions_batch_post.py
+++ b/chemscraper/fast_api_client/api/default/index_pdfs_reactions_batch_index_pdfs_reactions_batch_post.py
@@ -1,0 +1,184 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.body_index_pdfs_reactions_batch_index_pdfs_reactions_batch_post import (
+    BodyIndexPdfsReactionsBatchIndexPdfsReactionsBatchPost,
+)
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response
+
+
+def _get_kwargs(
+    *,
+    body: BodyIndexPdfsReactionsBatchIndexPdfsReactionsBatchPost,
+    index_name: str,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    params: dict[str, Any] = {}
+
+    params["index_name"] = index_name
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/index_pdfs_reactions_batch",
+        "params": params,
+    }
+
+    _body = body.to_multipart()
+
+    _kwargs["files"] = _body
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[Any, HTTPValidationError]]:
+    if response.status_code == 200:
+        response_200 = response.json()
+        return response_200
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Any, HTTPValidationError]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: BodyIndexPdfsReactionsBatchIndexPdfsReactionsBatchPost,
+    index_name: str,
+) -> Response[Union[Any, HTTPValidationError]]:
+    """Index Pdfs Reactions Batch
+
+    Args:
+        index_name (str):
+        body (BodyIndexPdfsReactionsBatchIndexPdfsReactionsBatchPost):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, HTTPValidationError]]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        index_name=index_name,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: BodyIndexPdfsReactionsBatchIndexPdfsReactionsBatchPost,
+    index_name: str,
+) -> Optional[Union[Any, HTTPValidationError]]:
+    """Index Pdfs Reactions Batch
+
+    Args:
+        index_name (str):
+        body (BodyIndexPdfsReactionsBatchIndexPdfsReactionsBatchPost):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, HTTPValidationError]
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+        index_name=index_name,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: BodyIndexPdfsReactionsBatchIndexPdfsReactionsBatchPost,
+    index_name: str,
+) -> Response[Union[Any, HTTPValidationError]]:
+    """Index Pdfs Reactions Batch
+
+    Args:
+        index_name (str):
+        body (BodyIndexPdfsReactionsBatchIndexPdfsReactionsBatchPost):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, HTTPValidationError]]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+        index_name=index_name,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: BodyIndexPdfsReactionsBatchIndexPdfsReactionsBatchPost,
+    index_name: str,
+) -> Optional[Union[Any, HTTPValidationError]]:
+    """Index Pdfs Reactions Batch
+
+    Args:
+        index_name (str):
+        body (BodyIndexPdfsReactionsBatchIndexPdfsReactionsBatchPost):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, HTTPValidationError]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+            index_name=index_name,
+        )
+    ).parsed

--- a/chemscraper/fast_api_client/api/default/search_search_post.py
+++ b/chemscraper/fast_api_client/api/default/search_search_post.py
@@ -1,0 +1,191 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    *,
+    index_name: Union[Unset, str] = "",
+    text_query: Union[Unset, str] = "",
+    smiles_query: Union[Unset, str] = "",
+) -> dict[str, Any]:
+    params: dict[str, Any] = {}
+
+    params["index_name"] = index_name
+
+    params["text_query"] = text_query
+
+    params["smiles_query"] = smiles_query
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/search",
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[Any, HTTPValidationError]]:
+    if response.status_code == 200:
+        response_200 = response.json()
+        return response_200
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Any, HTTPValidationError]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    index_name: Union[Unset, str] = "",
+    text_query: Union[Unset, str] = "",
+    smiles_query: Union[Unset, str] = "",
+) -> Response[Union[Any, HTTPValidationError]]:
+    """Search
+
+    Args:
+        index_name (Union[Unset, str]):  Default: ''.
+        text_query (Union[Unset, str]):  Default: ''.
+        smiles_query (Union[Unset, str]):  Default: ''.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, HTTPValidationError]]
+    """
+
+    kwargs = _get_kwargs(
+        index_name=index_name,
+        text_query=text_query,
+        smiles_query=smiles_query,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    index_name: Union[Unset, str] = "",
+    text_query: Union[Unset, str] = "",
+    smiles_query: Union[Unset, str] = "",
+) -> Optional[Union[Any, HTTPValidationError]]:
+    """Search
+
+    Args:
+        index_name (Union[Unset, str]):  Default: ''.
+        text_query (Union[Unset, str]):  Default: ''.
+        smiles_query (Union[Unset, str]):  Default: ''.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, HTTPValidationError]
+    """
+
+    return sync_detailed(
+        client=client,
+        index_name=index_name,
+        text_query=text_query,
+        smiles_query=smiles_query,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    index_name: Union[Unset, str] = "",
+    text_query: Union[Unset, str] = "",
+    smiles_query: Union[Unset, str] = "",
+) -> Response[Union[Any, HTTPValidationError]]:
+    """Search
+
+    Args:
+        index_name (Union[Unset, str]):  Default: ''.
+        text_query (Union[Unset, str]):  Default: ''.
+        smiles_query (Union[Unset, str]):  Default: ''.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, HTTPValidationError]]
+    """
+
+    kwargs = _get_kwargs(
+        index_name=index_name,
+        text_query=text_query,
+        smiles_query=smiles_query,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    index_name: Union[Unset, str] = "",
+    text_query: Union[Unset, str] = "",
+    smiles_query: Union[Unset, str] = "",
+) -> Optional[Union[Any, HTTPValidationError]]:
+    """Search
+
+    Args:
+        index_name (Union[Unset, str]):  Default: ''.
+        text_query (Union[Unset, str]):  Default: ''.
+        smiles_query (Union[Unset, str]):  Default: ''.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, HTTPValidationError]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            index_name=index_name,
+            text_query=text_query,
+            smiles_query=smiles_query,
+        )
+    ).parsed

--- a/chemscraper/fast_api_client/api/default/visualize_visualize_post.py
+++ b/chemscraper/fast_api_client/api/default/visualize_visualize_post.py
@@ -1,0 +1,162 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.body_visualize_visualize_post import BodyVisualizeVisualizePost
+from ...models.http_validation_error import HTTPValidationError
+from ...types import Response
+
+
+def _get_kwargs(
+    *,
+    body: BodyVisualizeVisualizePost,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/visualize",
+    }
+
+    _body = body.to_multipart()
+
+    _kwargs["files"] = _body
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[Any, HTTPValidationError]]:
+    if response.status_code == 200:
+        response_200 = response.json()
+        return response_200
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Any, HTTPValidationError]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: BodyVisualizeVisualizePost,
+) -> Response[Union[Any, HTTPValidationError]]:
+    """Visualize
+
+    Args:
+        body (BodyVisualizeVisualizePost):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, HTTPValidationError]]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: BodyVisualizeVisualizePost,
+) -> Optional[Union[Any, HTTPValidationError]]:
+    """Visualize
+
+    Args:
+        body (BodyVisualizeVisualizePost):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, HTTPValidationError]
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: BodyVisualizeVisualizePost,
+) -> Response[Union[Any, HTTPValidationError]]:
+    """Visualize
+
+    Args:
+        body (BodyVisualizeVisualizePost):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, HTTPValidationError]]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: BodyVisualizeVisualizePost,
+) -> Optional[Union[Any, HTTPValidationError]]:
+    """Visualize
+
+    Args:
+        body (BodyVisualizeVisualizePost):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, HTTPValidationError]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/chemscraper/fast_api_client/client.py
+++ b/chemscraper/fast_api_client/client.py
@@ -1,0 +1,268 @@
+import ssl
+from typing import Any, Optional, Union
+
+import httpx
+from attrs import define, evolve, field
+
+
+@define
+class Client:
+    """A class for keeping track of data related to the API
+
+    The following are accepted as keyword arguments and will be used to construct httpx Clients internally:
+
+        ``base_url``: The base URL for the API, all requests are made to a relative path to this URL
+
+        ``cookies``: A dictionary of cookies to be sent with every request
+
+        ``headers``: A dictionary of headers to be sent with every request
+
+        ``timeout``: The maximum amount of a time a request can take. API functions will raise
+        httpx.TimeoutException if this is exceeded.
+
+        ``verify_ssl``: Whether or not to verify the SSL certificate of the API server. This should be True in production,
+        but can be set to False for testing purposes.
+
+        ``follow_redirects``: Whether or not to follow redirects. Default value is False.
+
+        ``httpx_args``: A dictionary of additional arguments to be passed to the ``httpx.Client`` and ``httpx.AsyncClient`` constructor.
+
+
+    Attributes:
+        raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a
+            status code that was not documented in the source OpenAPI document. Can also be provided as a keyword
+            argument to the constructor.
+    """
+
+    raise_on_unexpected_status: bool = field(default=False, kw_only=True)
+    _base_url: str = field(alias="base_url")
+    _cookies: dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
+    _headers: dict[str, str] = field(factory=dict, kw_only=True, alias="headers")
+    _timeout: Optional[httpx.Timeout] = field(default=None, kw_only=True, alias="timeout")
+    _verify_ssl: Union[str, bool, ssl.SSLContext] = field(default=True, kw_only=True, alias="verify_ssl")
+    _follow_redirects: bool = field(default=False, kw_only=True, alias="follow_redirects")
+    _httpx_args: dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
+    _client: Optional[httpx.Client] = field(default=None, init=False)
+    _async_client: Optional[httpx.AsyncClient] = field(default=None, init=False)
+
+    def with_headers(self, headers: dict[str, str]) -> "Client":
+        """Get a new client matching this one with additional headers"""
+        if self._client is not None:
+            self._client.headers.update(headers)
+        if self._async_client is not None:
+            self._async_client.headers.update(headers)
+        return evolve(self, headers={**self._headers, **headers})
+
+    def with_cookies(self, cookies: dict[str, str]) -> "Client":
+        """Get a new client matching this one with additional cookies"""
+        if self._client is not None:
+            self._client.cookies.update(cookies)
+        if self._async_client is not None:
+            self._async_client.cookies.update(cookies)
+        return evolve(self, cookies={**self._cookies, **cookies})
+
+    def with_timeout(self, timeout: httpx.Timeout) -> "Client":
+        """Get a new client matching this one with a new timeout (in seconds)"""
+        if self._client is not None:
+            self._client.timeout = timeout
+        if self._async_client is not None:
+            self._async_client.timeout = timeout
+        return evolve(self, timeout=timeout)
+
+    def set_httpx_client(self, client: httpx.Client) -> "Client":
+        """Manually set the underlying httpx.Client
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._client = client
+        return self
+
+    def get_httpx_client(self) -> httpx.Client:
+        """Get the underlying httpx.Client, constructing a new one if not previously set"""
+        if self._client is None:
+            self._client = httpx.Client(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._client
+
+    def __enter__(self) -> "Client":
+        """Enter a context manager for self.client—you cannot enter twice (see httpx docs)"""
+        self.get_httpx_client().__enter__()
+        return self
+
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for internal httpx.Client (see httpx docs)"""
+        self.get_httpx_client().__exit__(*args, **kwargs)
+
+    def set_async_httpx_client(self, async_client: httpx.AsyncClient) -> "Client":
+        """Manually the underlying httpx.AsyncClient
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._async_client = async_client
+        return self
+
+    def get_async_httpx_client(self) -> httpx.AsyncClient:
+        """Get the underlying httpx.AsyncClient, constructing a new one if not previously set"""
+        if self._async_client is None:
+            self._async_client = httpx.AsyncClient(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._async_client
+
+    async def __aenter__(self) -> "Client":
+        """Enter a context manager for underlying httpx.AsyncClient—you cannot enter twice (see httpx docs)"""
+        await self.get_async_httpx_client().__aenter__()
+        return self
+
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for underlying httpx.AsyncClient (see httpx docs)"""
+        await self.get_async_httpx_client().__aexit__(*args, **kwargs)
+
+
+@define
+class AuthenticatedClient:
+    """A Client which has been authenticated for use on secured endpoints
+
+    The following are accepted as keyword arguments and will be used to construct httpx Clients internally:
+
+        ``base_url``: The base URL for the API, all requests are made to a relative path to this URL
+
+        ``cookies``: A dictionary of cookies to be sent with every request
+
+        ``headers``: A dictionary of headers to be sent with every request
+
+        ``timeout``: The maximum amount of a time a request can take. API functions will raise
+        httpx.TimeoutException if this is exceeded.
+
+        ``verify_ssl``: Whether or not to verify the SSL certificate of the API server. This should be True in production,
+        but can be set to False for testing purposes.
+
+        ``follow_redirects``: Whether or not to follow redirects. Default value is False.
+
+        ``httpx_args``: A dictionary of additional arguments to be passed to the ``httpx.Client`` and ``httpx.AsyncClient`` constructor.
+
+
+    Attributes:
+        raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a
+            status code that was not documented in the source OpenAPI document. Can also be provided as a keyword
+            argument to the constructor.
+        token: The token to use for authentication
+        prefix: The prefix to use for the Authorization header
+        auth_header_name: The name of the Authorization header
+    """
+
+    raise_on_unexpected_status: bool = field(default=False, kw_only=True)
+    _base_url: str = field(alias="base_url")
+    _cookies: dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
+    _headers: dict[str, str] = field(factory=dict, kw_only=True, alias="headers")
+    _timeout: Optional[httpx.Timeout] = field(default=None, kw_only=True, alias="timeout")
+    _verify_ssl: Union[str, bool, ssl.SSLContext] = field(default=True, kw_only=True, alias="verify_ssl")
+    _follow_redirects: bool = field(default=False, kw_only=True, alias="follow_redirects")
+    _httpx_args: dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
+    _client: Optional[httpx.Client] = field(default=None, init=False)
+    _async_client: Optional[httpx.AsyncClient] = field(default=None, init=False)
+
+    token: str
+    prefix: str = "Bearer"
+    auth_header_name: str = "Authorization"
+
+    def with_headers(self, headers: dict[str, str]) -> "AuthenticatedClient":
+        """Get a new client matching this one with additional headers"""
+        if self._client is not None:
+            self._client.headers.update(headers)
+        if self._async_client is not None:
+            self._async_client.headers.update(headers)
+        return evolve(self, headers={**self._headers, **headers})
+
+    def with_cookies(self, cookies: dict[str, str]) -> "AuthenticatedClient":
+        """Get a new client matching this one with additional cookies"""
+        if self._client is not None:
+            self._client.cookies.update(cookies)
+        if self._async_client is not None:
+            self._async_client.cookies.update(cookies)
+        return evolve(self, cookies={**self._cookies, **cookies})
+
+    def with_timeout(self, timeout: httpx.Timeout) -> "AuthenticatedClient":
+        """Get a new client matching this one with a new timeout (in seconds)"""
+        if self._client is not None:
+            self._client.timeout = timeout
+        if self._async_client is not None:
+            self._async_client.timeout = timeout
+        return evolve(self, timeout=timeout)
+
+    def set_httpx_client(self, client: httpx.Client) -> "AuthenticatedClient":
+        """Manually set the underlying httpx.Client
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._client = client
+        return self
+
+    def get_httpx_client(self) -> httpx.Client:
+        """Get the underlying httpx.Client, constructing a new one if not previously set"""
+        if self._client is None:
+            self._headers[self.auth_header_name] = f"{self.prefix} {self.token}" if self.prefix else self.token
+            self._client = httpx.Client(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._client
+
+    def __enter__(self) -> "AuthenticatedClient":
+        """Enter a context manager for self.client—you cannot enter twice (see httpx docs)"""
+        self.get_httpx_client().__enter__()
+        return self
+
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for internal httpx.Client (see httpx docs)"""
+        self.get_httpx_client().__exit__(*args, **kwargs)
+
+    def set_async_httpx_client(self, async_client: httpx.AsyncClient) -> "AuthenticatedClient":
+        """Manually the underlying httpx.AsyncClient
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._async_client = async_client
+        return self
+
+    def get_async_httpx_client(self) -> httpx.AsyncClient:
+        """Get the underlying httpx.AsyncClient, constructing a new one if not previously set"""
+        if self._async_client is None:
+            self._headers[self.auth_header_name] = f"{self.prefix} {self.token}" if self.prefix else self.token
+            self._async_client = httpx.AsyncClient(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._async_client
+
+    async def __aenter__(self) -> "AuthenticatedClient":
+        """Enter a context manager for underlying httpx.AsyncClient—you cannot enter twice (see httpx docs)"""
+        await self.get_async_httpx_client().__aenter__()
+        return self
+
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for underlying httpx.AsyncClient (see httpx docs)"""
+        await self.get_async_httpx_client().__aexit__(*args, **kwargs)

--- a/chemscraper/fast_api_client/errors.py
+++ b/chemscraper/fast_api_client/errors.py
@@ -1,0 +1,16 @@
+"""Contains shared errors types that can be raised from API functions"""
+
+
+class UnexpectedStatus(Exception):
+    """Raised by api functions when the response status an undocumented status and Client.raise_on_unexpected_status is True"""
+
+    def __init__(self, status_code: int, content: bytes):
+        self.status_code = status_code
+        self.content = content
+
+        super().__init__(
+            f"Unexpected status code: {status_code}\n\nResponse content:\n{content.decode(errors='ignore')}"
+        )
+
+
+__all__ = ["UnexpectedStatus"]

--- a/chemscraper/fast_api_client/models/__init__.py
+++ b/chemscraper/fast_api_client/models/__init__.py
@@ -1,0 +1,19 @@
+"""Contains all the data models used in inputs/outputs"""
+
+from .body_extract_extract_pdf_post import BodyExtractExtractPdfPost
+from .body_extract_reaction_miner_matching_post import BodyExtractReactionMinerMatchingPost
+from .body_index_pdfs_reactions_batch_index_pdfs_reactions_batch_post import (
+    BodyIndexPdfsReactionsBatchIndexPdfsReactionsBatchPost,
+)
+from .body_visualize_visualize_post import BodyVisualizeVisualizePost
+from .http_validation_error import HTTPValidationError
+from .validation_error import ValidationError
+
+__all__ = (
+    "BodyExtractExtractPdfPost",
+    "BodyExtractReactionMinerMatchingPost",
+    "BodyIndexPdfsReactionsBatchIndexPdfsReactionsBatchPost",
+    "BodyVisualizeVisualizePost",
+    "HTTPValidationError",
+    "ValidationError",
+)

--- a/chemscraper/fast_api_client/models/body_extract_extract_pdf_post.py
+++ b/chemscraper/fast_api_client/models/body_extract_extract_pdf_post.py
@@ -1,0 +1,76 @@
+from io import BytesIO
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import File
+
+T = TypeVar("T", bound="BodyExtractExtractPdfPost")
+
+
+@_attrs_define
+class BodyExtractExtractPdfPost:
+    """
+    Attributes:
+        pdf (File):
+    """
+
+    pdf: File
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        pdf = self.pdf.to_tuple()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "pdf": pdf,
+            }
+        )
+
+        return field_dict
+
+    def to_multipart(self) -> dict[str, Any]:
+        pdf = self.pdf.to_tuple()
+
+        field_dict: dict[str, Any] = {}
+        for prop_name, prop in self.additional_properties.items():
+            field_dict[prop_name] = (None, str(prop).encode(), "text/plain")
+
+        field_dict.update(
+            {
+                "pdf": pdf,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
+        d = src_dict.copy()
+        pdf = File(payload=BytesIO(d.pop("pdf")))
+
+        body_extract_extract_pdf_post = cls(
+            pdf=pdf,
+        )
+
+        body_extract_extract_pdf_post.additional_properties = d
+        return body_extract_extract_pdf_post
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/chemscraper/fast_api_client/models/body_extract_reaction_miner_matching_post.py
+++ b/chemscraper/fast_api_client/models/body_extract_reaction_miner_matching_post.py
@@ -1,0 +1,87 @@
+from io import BytesIO
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import File
+
+T = TypeVar("T", bound="BodyExtractReactionMinerMatchingPost")
+
+
+@_attrs_define
+class BodyExtractReactionMinerMatchingPost:
+    """
+    Attributes:
+        pdf (File):
+        reaction_miner_json_file (File):
+    """
+
+    pdf: File
+    reaction_miner_json_file: File
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        pdf = self.pdf.to_tuple()
+
+        reaction_miner_json_file = self.reaction_miner_json_file.to_tuple()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "pdf": pdf,
+                "reaction_miner_json_file": reaction_miner_json_file,
+            }
+        )
+
+        return field_dict
+
+    def to_multipart(self) -> dict[str, Any]:
+        pdf = self.pdf.to_tuple()
+
+        reaction_miner_json_file = self.reaction_miner_json_file.to_tuple()
+
+        field_dict: dict[str, Any] = {}
+        for prop_name, prop in self.additional_properties.items():
+            field_dict[prop_name] = (None, str(prop).encode(), "text/plain")
+
+        field_dict.update(
+            {
+                "pdf": pdf,
+                "reaction_miner_json_file": reaction_miner_json_file,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
+        d = src_dict.copy()
+        pdf = File(payload=BytesIO(d.pop("pdf")))
+
+        reaction_miner_json_file = File(payload=BytesIO(d.pop("reaction_miner_json_file")))
+
+        body_extract_reaction_miner_matching_post = cls(
+            pdf=pdf,
+            reaction_miner_json_file=reaction_miner_json_file,
+        )
+
+        body_extract_reaction_miner_matching_post.additional_properties = d
+        return body_extract_reaction_miner_matching_post
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/chemscraper/fast_api_client/models/body_index_pdfs_reactions_batch_index_pdfs_reactions_batch_post.py
+++ b/chemscraper/fast_api_client/models/body_index_pdfs_reactions_batch_index_pdfs_reactions_batch_post.py
@@ -1,0 +1,122 @@
+import json
+from io import BytesIO
+from typing import Any, TypeVar, Tuple
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import File, FileJsonType, UNSET
+
+T = TypeVar("T", bound="BodyIndexPdfsReactionsBatchIndexPdfsReactionsBatchPost")
+
+
+@_attrs_define
+class BodyIndexPdfsReactionsBatchIndexPdfsReactionsBatchPost:
+    """
+    Attributes:
+        pdf_files (list[File]):
+        json_reaction_files (list[File]):
+        mapping_file (File):
+    """
+
+    pdf_files: list[File]
+    json_reaction_files: list[File]
+    mapping_file: File
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        pdf_files = []
+        for pdf_files_item_data in self.pdf_files:
+            pdf_files_item = pdf_files_item_data.to_tuple()
+
+            pdf_files.append(pdf_files_item)
+
+        json_reaction_files = []
+        for json_reaction_files_item_data in self.json_reaction_files:
+            json_reaction_files_item = json_reaction_files_item_data.to_tuple()
+
+            json_reaction_files.append(json_reaction_files_item)
+
+        mapping_file = self.mapping_file.to_tuple()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "pdf_files": pdf_files,
+                "json_reaction_files": json_reaction_files,
+                "mapping_file": mapping_file,
+            }
+        )
+
+        return field_dict
+
+    def to_multipart(self) -> list[Tuple[str, FileJsonType]]:
+        field_dict: list[Tuple[str, FileJsonType]] = []
+        for key, value in self.additional_properties.items():
+            field_dict.append((key, (None, str(value).encode(), "text/plain")))
+
+        if self.pdf_files is not UNSET:
+            for pdf_files_item in self.pdf_files:
+                field_dict.append(("pdf_files", pdf_files_item.to_tuple()))
+
+        if self.json_reaction_files is not UNSET:
+            for json_files_item in self.json_reaction_files:
+                field_dict.append(("json_reaction_files", json_files_item.to_tuple()))
+
+        mapping_file = self.mapping_file.to_tuple()
+        field_dict.append(("mapping_file", mapping_file))
+
+        # field_dict.update(
+        #     {
+        #         "pdf_files": pdf_files,
+        #         "json_reaction_files": json_reaction_files,
+        #         "mapping_file": mapping_file,
+        #     }
+        # )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
+        d = src_dict.copy()
+        pdf_files = []
+        _pdf_files = d.pop("pdf_files")
+        for pdf_files_item_data in _pdf_files:
+            pdf_files_item = File(payload=BytesIO(pdf_files_item_data))
+
+            pdf_files.append(pdf_files_item)
+
+        json_reaction_files = []
+        _json_reaction_files = d.pop("json_reaction_files")
+        for json_reaction_files_item_data in _json_reaction_files:
+            json_reaction_files_item = File(payload=BytesIO(json_reaction_files_item_data))
+
+            json_reaction_files.append(json_reaction_files_item)
+
+        mapping_file = File(payload=BytesIO(d.pop("mapping_file")))
+
+        body_index_pdfs_reactions_batch_index_pdfs_reactions_batch_post = cls(
+            pdf_files=pdf_files,
+            json_reaction_files=json_reaction_files,
+            mapping_file=mapping_file,
+        )
+
+        body_index_pdfs_reactions_batch_index_pdfs_reactions_batch_post.additional_properties = d
+        return body_index_pdfs_reactions_batch_index_pdfs_reactions_batch_post
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/chemscraper/fast_api_client/models/body_visualize_visualize_post.py
+++ b/chemscraper/fast_api_client/models/body_visualize_visualize_post.py
@@ -1,0 +1,76 @@
+from io import BytesIO
+from typing import Any, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import File
+
+T = TypeVar("T", bound="BodyVisualizeVisualizePost")
+
+
+@_attrs_define
+class BodyVisualizeVisualizePost:
+    """
+    Attributes:
+        pdf (File):
+    """
+
+    pdf: File
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        pdf = self.pdf.to_tuple()
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "pdf": pdf,
+            }
+        )
+
+        return field_dict
+
+    def to_multipart(self) -> dict[str, Any]:
+        pdf = self.pdf.to_tuple()
+
+        field_dict: dict[str, Any] = {}
+        for prop_name, prop in self.additional_properties.items():
+            field_dict[prop_name] = (None, str(prop).encode(), "text/plain")
+
+        field_dict.update(
+            {
+                "pdf": pdf,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
+        d = src_dict.copy()
+        pdf = File(payload=BytesIO(d.pop("pdf")))
+
+        body_visualize_visualize_post = cls(
+            pdf=pdf,
+        )
+
+        body_visualize_visualize_post.additional_properties = d
+        return body_visualize_visualize_post
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/chemscraper/fast_api_client/models/http_validation_error.py
+++ b/chemscraper/fast_api_client/models/http_validation_error.py
@@ -1,0 +1,74 @@
+from typing import TYPE_CHECKING, Any, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.validation_error import ValidationError
+
+
+T = TypeVar("T", bound="HTTPValidationError")
+
+
+@_attrs_define
+class HTTPValidationError:
+    """
+    Attributes:
+        detail (Union[Unset, list['ValidationError']]):
+    """
+
+    detail: Union[Unset, list["ValidationError"]] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        detail: Union[Unset, list[dict[str, Any]]] = UNSET
+        if not isinstance(self.detail, Unset):
+            detail = []
+            for detail_item_data in self.detail:
+                detail_item = detail_item_data.to_dict()
+                detail.append(detail_item)
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if detail is not UNSET:
+            field_dict["detail"] = detail
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
+        from ..models.validation_error import ValidationError
+
+        d = src_dict.copy()
+        detail = []
+        _detail = d.pop("detail", UNSET)
+        for detail_item_data in _detail or []:
+            detail_item = ValidationError.from_dict(detail_item_data)
+
+            detail.append(detail_item)
+
+        http_validation_error = cls(
+            detail=detail,
+        )
+
+        http_validation_error.additional_properties = d
+        return http_validation_error
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/chemscraper/fast_api_client/models/validation_error.py
+++ b/chemscraper/fast_api_client/models/validation_error.py
@@ -1,0 +1,87 @@
+from typing import Any, TypeVar, Union, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="ValidationError")
+
+
+@_attrs_define
+class ValidationError:
+    """
+    Attributes:
+        loc (list[Union[int, str]]):
+        msg (str):
+        type_ (str):
+    """
+
+    loc: list[Union[int, str]]
+    msg: str
+    type_: str
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        loc = []
+        for loc_item_data in self.loc:
+            loc_item: Union[int, str]
+            loc_item = loc_item_data
+            loc.append(loc_item)
+
+        msg = self.msg
+
+        type_ = self.type_
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "loc": loc,
+                "msg": msg,
+                "type": type_,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: dict[str, Any]) -> T:
+        d = src_dict.copy()
+        loc = []
+        _loc = d.pop("loc")
+        for loc_item_data in _loc:
+
+            def _parse_loc_item(data: object) -> Union[int, str]:
+                return cast(Union[int, str], data)
+
+            loc_item = _parse_loc_item(loc_item_data)
+
+            loc.append(loc_item)
+
+        msg = d.pop("msg")
+
+        type_ = d.pop("type")
+
+        validation_error = cls(
+            loc=loc,
+            msg=msg,
+            type_=type_,
+        )
+
+        validation_error.additional_properties = d
+        return validation_error
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/chemscraper/fast_api_client/py.typed
+++ b/chemscraper/fast_api_client/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561

--- a/chemscraper/fast_api_client/types.py
+++ b/chemscraper/fast_api_client/types.py
@@ -1,0 +1,46 @@
+"""Contains some shared types for properties"""
+
+from collections.abc import MutableMapping
+from http import HTTPStatus
+from typing import BinaryIO, Generic, Literal, Optional, TypeVar
+
+from attrs import define
+
+
+class Unset:
+    def __bool__(self) -> Literal[False]:
+        return False
+
+
+UNSET: Unset = Unset()
+
+FileJsonType = tuple[Optional[str], BinaryIO, Optional[str]]
+
+
+@define
+class File:
+    """Contains information for file uploads"""
+
+    payload: BinaryIO
+    file_name: Optional[str] = None
+    mime_type: Optional[str] = None
+
+    def to_tuple(self) -> FileJsonType:
+        """Return a tuple representation that httpx will accept for multipart/form-data"""
+        return self.file_name, self.payload, self.mime_type
+
+
+T = TypeVar("T")
+
+
+@define
+class Response(Generic[T]):
+    """A response from an endpoint"""
+
+    status_code: HTTPStatus
+    content: bytes
+    headers: MutableMapping[str, str]
+    parsed: Optional[T]
+
+
+__all__ = ["UNSET", "File", "FileJsonType", "Response", "Unset"]

--- a/chemscraper/pyproject.toml
+++ b/chemscraper/pyproject.toml
@@ -1,0 +1,27 @@
+[tool.poetry]
+name = "fast-api-client"
+version = "0.1.0"
+description = "A client library for accessing FastAPI"
+authors = []
+readme = "README.md"
+packages = [
+    {include = "fast_api_client"},
+]
+include = ["CHANGELOG.md", "fast_api_client/py.typed"]
+
+
+[tool.poetry.dependencies]
+python = "^3.9"
+httpx = ">=0.20.0,<0.29.0"
+attrs = ">=22.2.0"
+python-dateutil = "^2.8.0"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.lint]
+select = ["F", "I", "UP"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -15,14 +15,14 @@ conda run --no-capture-output -n doc2json bash ./pdf2txt.sh
 
 # TODO: move files?
 
-# Run reactionminer example script in teh base conda env
+# Run reactionminer example script in the base conda env
 echo '###########################################'
 echo '#######    RUNNING ReactionMiner    #######'
 echo '###########################################'
 cd /workspace
 python ./example.py
 
-# Run reactionminer example script in teh base conda env
+# Run ChemScraper using input PDF and ReactionMiner JSON output
 echo '###########################################'
 echo '########    RUNNING ChemScraper    ########'
 echo '###########################################'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,3 +21,9 @@ echo '#######    RUNNING ReactionMiner    #######'
 echo '###########################################'
 cd /workspace
 python ./example.py
+
+# Run reactionminer example script in teh base conda env
+echo '###########################################'
+echo '########    RUNNING ChemScraper    ########'
+echo '###########################################'
+python ./run_chemscraper.py

--- a/run_chemscraper.py
+++ b/run_chemscraper.py
@@ -103,6 +103,13 @@ def submit_to_chemscraper(index_name, pdf_files, json_files, mapping):
             ))
 
             logger.debug("Response: " + str(response))
+
+            # Write JSON response
+            output_file_path = os.path.join(CHEMSCRAPER_OUTPUT_DIR, 'chemscraper-output.json')
+            logged.info(f'Writing response to file: {output_file_path}')
+            with open(output_file_path, "w") as f:
+                f.write(str(response))
+
     except Exception as ex:
         logger.error(f'ERROR: {ex}')
         sys.exit(1)

--- a/run_chemscraper.py
+++ b/run_chemscraper.py
@@ -1,0 +1,163 @@
+import logging
+import os
+import requests
+from typing import BinaryIO
+from io import BytesIO
+
+from chemscraper.fast_api_client import Client
+from chemscraper.fast_api_client.types import File
+from chemscraper.fast_api_client.api.default import index_pdfs_reactions_batch_index_pdfs_reactions_batch_post as index_pdfs_reactions_batch
+from chemscraper.fast_api_client.api.default.index_pdfs_reactions_batch_index_pdfs_reactions_batch_post import BodyIndexPdfsReactionsBatchIndexPdfsReactionsBatchPost as IndexPdfsReactionsBatchPostBody
+
+logging.basicConfig(
+    format="%(levelname)s [%(asctime)s] %(name)s - %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+    level=logging.DEBUG
+)
+logger = logging.getLogger('run_chemscraper')
+
+# Path to input PDFs for RM+CS
+CHEMSCRAPER_PDF_INPUT_DIR = os.environ.get('CHEMSCRAPER_PDF_INPUT_DIR', '/workspace/10test')
+
+# Path to output JSONs from ReactionMiner
+CHEMSCRAPER_REACTIONMINER_JSON_DIR = os.environ.get('CHEMSCRAPER_REACTIONMINER_JSON_DIR', '/workspace/extraction/results_filtered')
+
+# Path to output from full RM+CS workflow
+CHEMSCRAPER_OUTPUT_DIR = os.environ.get('CHEMSCRAPER_OUTPUT_DIR', '/workspace/extraction/results_filtered')
+
+# Path to output from full RM+CS workflow
+CHEMSCRAPER_INDEX_NAME = os.environ.get('CHEMSCRAPER_INDEX_NAME', os.environ.get('JOB_ID'))
+
+# Base URL to ChemScraper API
+CHEMSCRAPER_BASE_URL = os.environ.get('CHEMSCRAPER_BASE_URL', 'http://chemscraper-service-staging.staging.svc.cluster.local:8000')
+
+# Read PDFs + locate matching JSONs from disk
+def locate_matching_files(pdf_input_dir):
+    # Loop to build up CSV mapping and file lists
+    mapping = {}
+    pdf_files = []
+    json_files = []
+    file_uploads = []
+
+    for root, _, files in os.walk(pdf_input_dir):
+        logger.info(f"Current directory: {root}")
+        for file in files:
+            if file.endswith(".pdf"):
+                logger.info(f"  PDF File: {file}")
+                pdf_file_name = file
+                pdf_file_path = os.path.join(root, file)
+                json_file_name = file.replace('.pdf', '.json')
+                json_file_path = os.path.join(CHEMSCRAPER_REACTIONMINER_JSON_DIR, json_file_name)
+                if os.path.exists(json_file_path):
+                    # For each matching PDF-JSON pair, add to CSV mapping
+                    logger.info(f"  Matching JSON file found: {json_file_name}")
+                    mapping[file] = json_file_name
+                    file_uploads.append(('pdf_files', (pdf_file_name, open(pdf_file_path, 'rb'), 'application/pdf')))
+                    pdf_files.append(pdf_file_path)
+                    file_uploads.append(('json_files', (json_file_name, open(json_file_path, 'rb'), 'application/json')))
+                    json_files.append(json_file_path)
+                else:
+                    logger.warning(f"  No matching JSON file found: {file}")
+            else:
+                logger.debug(f"  Skipping non-PDF File: {file}")
+
+        logger.debug('PDF Files: ' + str(pdf_files))
+        logger.debug('JSON Files: ' + str(json_files))
+        logger.debug('Mapping: ' + str(mapping))
+
+        # Return lists of files and CSV mapping
+        return pdf_files, json_files, mapping, file_uploads
+
+
+# Write mapping.csv to file, and submit this file with our request
+def write_mapping_csv(mapping):
+    index = 0
+    with open(os.path.join(CHEMSCRAPER_REACTIONMINER_JSON_DIR, 'mapping.csv'), 'w') as f:
+        f.write(f'id,pdf_name,json_name\n')
+        for pdf_file in mapping:
+            json_file = mapping[pdf_file]
+            f.write(f'{index},{pdf_file},{json_file}\n')
+            index += 1
+
+# Submit mapping + related files to Chemscraper API
+def submit_to_chemscraper(index_name, pdf_files, json_files, mapping):
+    try:
+        with Client(base_url=CHEMSCRAPER_BASE_URL) as client:
+            response = index_pdfs_reactions_batch.sync(client=client, index_name=index_name, body=IndexPdfsReactionsBatchPostBody(
+                pdf_files=[File(
+                    file_name=file.split('/')[-1],
+                    payload=read_file_bytes(os.path.join(CHEMSCRAPER_PDF_INPUT_DIR, file)),
+                    mime_type='application/pdf'
+                ) for file in pdf_files],
+                json_reaction_files=[File(
+                    file_name=file.split('/')[-1],
+                    payload=read_file_bytes(os.path.join(CHEMSCRAPER_REACTIONMINER_JSON_DIR, file)),
+                    mime_type='application/json'
+                ) for file in json_files],
+                mapping_file=File(
+                    file_name='mapping.csv',
+                    payload=read_file_bytes(os.path.join(CHEMSCRAPER_REACTIONMINER_JSON_DIR, 'mapping.csv')),
+                    mime_type='text/csv'
+                ),
+            ))
+
+            logger.debug("Response: " + str(response))
+    except Exception as ex:
+        logger.error(f'ERROR: {ex}')
+
+# TODO: Read large files in chunks?
+def read_file_bytes(path) -> BinaryIO:
+    with open(path, mode='rb') as f:
+        return BytesIO(f.read())
+    #return open(path, mode='rb')
+
+
+def main():
+    logger.info(f'Submitting these files to ChemScraper')
+    logger.info(f'  Index Name: {CHEMSCRAPER_INDEX_NAME}')
+    logger.info(f'  PDF  Input Dir: {CHEMSCRAPER_PDF_INPUT_DIR}')
+    logger.info(f'  JSON Input Dir: {CHEMSCRAPER_REACTIONMINER_JSON_DIR}')
+    logger.info(f'  Output Dir: {CHEMSCRAPER_OUTPUT_DIR}')
+
+    pdf_files, json_files, mapping, file_uploads = locate_matching_files(pdf_input_dir=CHEMSCRAPER_PDF_INPUT_DIR)
+    write_mapping_csv(mapping)
+    submit_to_chemscraper(index_name=CHEMSCRAPER_INDEX_NAME, pdf_files=pdf_files, json_files=json_files, mapping=mapping)
+
+if __name__ == "__main__":
+    main()
+
+
+
+#
+# try:
+#     params = {
+#         'index_name': CHEMSCRAPER_INDEX_NAME
+#     }
+#     print('Params: ' + str(params))
+#     file_uploads.append(('mapping_file', mapping_file))
+#     print('File Uploads: ' + str(file_uploads))
+#     response = requests.post(url=url, params=params, data=file_uploads)
+#
+#     #  Wait for response
+#     if response.ok:
+#         print('Upload successful. Saving response locally...')
+#         # TODO: Save output files to disk so they are uploaded to MinIO
+#         output_file_path = os.path.join('/workspace/extraction/results_filtered', 'reactionminer-chemscraper-output.json')
+#         print(response.text)
+#         with open(output_file_path, 'w') as f:
+#             f.write(response.text)
+#     else:
+#         print(f'Error: Upload failed - {response.status_code} - ')
+#         response.raise_for_status()
+#
+# except requests.exceptions.HTTPError as errh:
+#     print(f"HTTP Error: {errh}")
+# except requests.exceptions.ConnectionError as errc:
+#     print(f"Connection Error: {errc}")
+# except requests.exceptions.Timeout as errt:
+#     print(f"Timeout Error: {errt}")
+# except requests.exceptions.RequestException as err:
+#     print(f"Something went wrong: {err}")
+#
+#
+#

--- a/run_chemscraper.py
+++ b/run_chemscraper.py
@@ -106,7 +106,7 @@ def submit_to_chemscraper(index_name, pdf_files, json_files, mapping):
 
             # Write JSON response
             output_file_path = os.path.join(CHEMSCRAPER_OUTPUT_DIR, 'chemscraper-output.json')
-            logged.info(f'Writing response to file: {output_file_path}')
+            logger.info(f'Writing response to file: {output_file_path}')
             with open(output_file_path, "w") as f:
                 f.write(str(response))
 

--- a/run_chemscraper.py
+++ b/run_chemscraper.py
@@ -77,7 +77,7 @@ def parse_input_files(pdf_input_dir):
         logger.debug('Mapping: ' + str(mapping))
 
         # Return lists of files and CSV mapping
-        return pdf_files, json_files, mapping, file_uploads
+        return pdf_files, json_files, mapping
 
 
 # Write mapping.csv to file, and submit this file with our request

--- a/run_chemscraper.py
+++ b/run_chemscraper.py
@@ -18,49 +18,59 @@ logging.basicConfig(
 logger = logging.getLogger('run_chemscraper')
 
 # Path to input PDFs for RM+CS
+# Files in this path will be automatically downloaded from MinIO before running the AlphaSynthesis job
 CHEMSCRAPER_PDF_INPUT_DIR = os.environ.get('CHEMSCRAPER_PDF_INPUT_DIR', '/workspace/10test')
 
 # Path to output JSONs from ReactionMiner
+# Files in this path will be automatically uploaded to MinIO after running the AlphaSynthesis job
 CHEMSCRAPER_REACTIONMINER_JSON_DIR = os.environ.get('CHEMSCRAPER_REACTIONMINER_JSON_DIR', '/workspace/extraction/results_filtered')
 
 # Path to output from full RM+CS workflow
-CHEMSCRAPER_OUTPUT_DIR = os.environ.get('CHEMSCRAPER_OUTPUT_DIR', '/workspace/extraction/results_filtered')
+# We store to the same path as ReactionMiner outputs, so that this is also uploaded to MinIO
+CHEMSCRAPER_OUTPUT_DIR = os.environ.get('CHEMSCRAPER_OUTPUT_DIR', CHEMSCRAPER_REACTIONMINER_JSON_DIR)
 
-# Path to output from full RM+CS workflow
-CHEMSCRAPER_INDEX_NAME = os.environ.get('CHEMSCRAPER_INDEX_NAME', os.environ.get('JOB_ID'))
+# A unique string identifier for this searchable index
+# Used when submitting to the /search endpoint
+CHEMSCRAPER_INDEX_NAME = os.environ.get('CHEMSCRAPER_INDEX_NAME', os.environ.get('JOB_ID', 'test'))
 
 # Base URL to ChemScraper API
+# We will override this default in production
 CHEMSCRAPER_BASE_URL = os.environ.get('CHEMSCRAPER_BASE_URL', 'http://chemscraper-services-staging.staging.svc.cluster.local:8000')
 
-# Read PDFs + locate matching JSONs from disk
-def locate_matching_files(pdf_input_dir):
+# Read PDFs + locate matching JSONs on disk
+# Create a mapping of PDF file -> JSON file
+def parse_input_files(pdf_input_dir):
     # Loop to build up CSV mapping and file lists
     mapping = {}
     pdf_files = []
     json_files = []
-    file_uploads = []
 
+    # Walk input PDF directory looking for PDF files
     for root, _, files in os.walk(pdf_input_dir):
         logger.info(f"Current directory: {root}")
         for file in files:
-            if file.endswith(".pdf"):
-                logger.info(f"  PDF File: {file}")
+            # Skip non-PDF files
+            if not file.endswith(".pdf"):
+                logger.debug(f"  Skipping non-PDF File: {file}")
+            else:
+                # If a PDF is found, check for a matching JSON file
                 pdf_file_name = file
+                logger.info(f"  PDF File: {pdf_file_name}")
                 pdf_file_path = os.path.join(root, file)
-                json_file_name = file.replace('.pdf', '.json')
+                json_file_name = pdf_file_name.replace('.pdf', '.json')
                 json_file_path = os.path.join(CHEMSCRAPER_REACTIONMINER_JSON_DIR, json_file_name)
-                if os.path.exists(json_file_path):
+
+                # Skip processing PDFs where no matching JSON is found
+                if not os.path.exists(json_file_path):
+                    logger.warning(f"  No matching JSON file found: {file}")
+                else:
                     # For each matching PDF-JSON pair, add to CSV mapping
                     logger.info(f"  Matching JSON file found: {json_file_name}")
-                    mapping[file] = json_file_name
-                    file_uploads.append(('pdf_files', (pdf_file_name, open(pdf_file_path, 'rb'), 'application/pdf')))
+
+                    # Maintain lists of these pairs to submit at the end
+                    mapping[pdf_file_name] = json_file_name
                     pdf_files.append(pdf_file_path)
-                    file_uploads.append(('json_files', (json_file_name, open(json_file_path, 'rb'), 'application/json')))
                     json_files.append(json_file_path)
-                else:
-                    logger.warning(f"  No matching JSON file found: {file}")
-            else:
-                logger.debug(f"  Skipping non-PDF File: {file}")
 
         logger.debug('PDF Files: ' + str(pdf_files))
         logger.debug('JSON Files: ' + str(json_files))
@@ -71,102 +81,79 @@ def locate_matching_files(pdf_input_dir):
 
 
 # Write mapping.csv to file, and submit this file with our request
-def write_mapping_csv(mapping):
+def save_mapping_csv(file_path, mapping):
     index = 0
-    with open(os.path.join(CHEMSCRAPER_REACTIONMINER_JSON_DIR, 'mapping.csv'), 'w') as f:
+    with open(file_path, 'w') as f:
+        # Write CSV headers - this is important
         f.write(f'id,pdf_name,json_name\n')
         for pdf_file in mapping:
+            # Read mapping to write CSV line by line
             json_file = mapping[pdf_file]
             f.write(f'{index},{pdf_file},{json_file}\n')
             index += 1
 
 # Submit mapping + related files to Chemscraper API
 def submit_to_chemscraper(index_name, pdf_files, json_files, mapping):
-    try:
-        with Client(base_url=CHEMSCRAPER_BASE_URL) as client:
-            response = index_pdfs_reactions_batch.sync(client=client, index_name=index_name, body=IndexPdfsReactionsBatchPostBody(
-                pdf_files=[File(
-                    file_name=file.split('/')[-1],
-                    payload=read_file_bytes(os.path.join(CHEMSCRAPER_PDF_INPUT_DIR, file)),
-                    mime_type='application/pdf'
-                ) for file in pdf_files],
-                json_reaction_files=[File(
-                    file_name=file.split('/')[-1],
-                    payload=read_file_bytes(os.path.join(CHEMSCRAPER_REACTIONMINER_JSON_DIR, file)),
-                    mime_type='application/json'
-                ) for file in json_files],
-                mapping_file=File(
-                    file_name='mapping.csv',
-                    payload=read_file_bytes(os.path.join(CHEMSCRAPER_REACTIONMINER_JSON_DIR, 'mapping.csv')),
-                    mime_type='text/csv'
-                ),
-            ))
+    # Save mapping.csv to disk, upload to MinIO later
+    mapping_csv_file_path = os.path.join(CHEMSCRAPER_REACTIONMINER_JSON_DIR, 'mapping.csv')
+    save_mapping_csv(file_path=mapping_csv_file_path, mapping=mapping)
 
-            logger.debug("Response: " + str(response))
+    # Create a new ChemScraper API client and submit the
+    # PDF + JSON files and the mapping that links them
+    with Client(base_url=CHEMSCRAPER_BASE_URL) as client:
+        return index_pdfs_reactions_batch.sync(client=client, index_name=index_name, body=IndexPdfsReactionsBatchPostBody(
+            # Our list of ReactionMiner PDF inputs
+            pdf_files=[File(
+                file_name=file.split('/')[-1],
+                payload=read_file_bytes(os.path.join(CHEMSCRAPER_PDF_INPUT_DIR, file)),
+                mime_type='application/pdf'
+            ) for file in pdf_files],
 
-            # Write JSON response
-            output_file_path = os.path.join(CHEMSCRAPER_OUTPUT_DIR, 'chemscraper-output.json')
-            logger.info(f'Writing response to file: {output_file_path}')
-            with open(output_file_path, "w") as f:
-                f.write(str(response))
+            # Our list of ReactionMiner JSON outputs
+            json_reaction_files=[File(
+                file_name=file.split('/')[-1],
+                payload=read_file_bytes(os.path.join(CHEMSCRAPER_REACTIONMINER_JSON_DIR, file)),
+                mime_type='application/json'
+            ) for file in json_files],
 
-    except Exception as ex:
-        logger.error(f'ERROR: {ex}')
-        sys.exit(1)
+            # The CSV created earlier that maps PDF file -> JSON file
+            mapping_file=File(
+                file_name='mapping.csv',
+                payload=read_file_bytes(os.path.join(CHEMSCRAPER_REACTIONMINER_JSON_DIR, 'mapping.csv')),
+                mime_type='text/csv'
+            ),
+        ))
 
 # TODO: Read large files in chunks?
 def read_file_bytes(path) -> BinaryIO:
     with open(path, mode='rb') as f:
         return BytesIO(f.read())
-    #return open(path, mode='rb')
 
 
-def main():
+# Write ChemScraper JSON response to file
+def write_json_output(output_file_path):
+    logger.info(f'Writing response to file: {output_file_path}')
+    with open(output_file_path, "w") as f:
+        f.write(str(response))
+
+# Walk directory and build up a mapping to submit to ChemScraper
+# exit with error code = 1 if any error encountered
+# (error code = 0 indicates success)
+if __name__ == "__main__":
     logger.info(f'Submitting these files to ChemScraper')
     logger.info(f'  Index Name: {CHEMSCRAPER_INDEX_NAME}')
     logger.info(f'  PDF  Input Dir: {CHEMSCRAPER_PDF_INPUT_DIR}')
     logger.info(f'  JSON Input Dir: {CHEMSCRAPER_REACTIONMINER_JSON_DIR}')
     logger.info(f'  Output Dir: {CHEMSCRAPER_OUTPUT_DIR}')
 
-    pdf_files, json_files, mapping, file_uploads = locate_matching_files(pdf_input_dir=CHEMSCRAPER_PDF_INPUT_DIR)
-    write_mapping_csv(mapping)
-    submit_to_chemscraper(index_name=CHEMSCRAPER_INDEX_NAME, pdf_files=pdf_files, json_files=json_files, mapping=mapping)
+    try:
+        pdf_files, json_files, mapping = parse_input_files(pdf_input_dir=CHEMSCRAPER_PDF_INPUT_DIR)
+        response = submit_to_chemscraper(index_name=CHEMSCRAPER_INDEX_NAME, pdf_files=pdf_files, json_files=json_files, mapping=mapping)
+        logger.debug("Response: " + str(response))
 
-if __name__ == "__main__":
-    main()
-
-
-
-#
-# try:
-#     params = {
-#         'index_name': CHEMSCRAPER_INDEX_NAME
-#     }
-#     print('Params: ' + str(params))
-#     file_uploads.append(('mapping_file', mapping_file))
-#     print('File Uploads: ' + str(file_uploads))
-#     response = requests.post(url=url, params=params, data=file_uploads)
-#
-#     #  Wait for response
-#     if response.ok:
-#         print('Upload successful. Saving response locally...')
-#         # TODO: Save output files to disk so they are uploaded to MinIO
-#         output_file_path = os.path.join('/workspace/extraction/results_filtered', 'reactionminer-chemscraper-output.json')
-#         print(response.text)
-#         with open(output_file_path, 'w') as f:
-#             f.write(response.text)
-#     else:
-#         print(f'Error: Upload failed - {response.status_code} - ')
-#         response.raise_for_status()
-#
-# except requests.exceptions.HTTPError as errh:
-#     print(f"HTTP Error: {errh}")
-# except requests.exceptions.ConnectionError as errc:
-#     print(f"Connection Error: {errc}")
-# except requests.exceptions.Timeout as errt:
-#     print(f"Timeout Error: {errt}")
-# except requests.exceptions.RequestException as err:
-#     print(f"Something went wrong: {err}")
-#
-#
-#
+        # Write JSON response
+        output_file_path = os.path.join(CHEMSCRAPER_OUTPUT_DIR, 'chemscraper-output.json')
+        write_json_output(output_file_path=output_file_path)
+    except Exception as ex:
+        logger.error(f'ERROR: {ex}')
+        sys.exit(1)

--- a/run_chemscraper.py
+++ b/run_chemscraper.py
@@ -149,11 +149,15 @@ if __name__ == "__main__":
     try:
         pdf_files, json_files, mapping = parse_input_files(pdf_input_dir=CHEMSCRAPER_PDF_INPUT_DIR)
         response = submit_to_chemscraper(index_name=CHEMSCRAPER_INDEX_NAME, pdf_files=pdf_files, json_files=json_files, mapping=mapping)
-        logger.debug("Response: " + str(response))
 
-        # Write JSON response
-        output_file_path = os.path.join(CHEMSCRAPER_OUTPUT_DIR, 'chemscraper-output.json')
-        write_json_output(output_file_path=output_file_path)
+        # Write JSON response to file
+        if response is not None:
+            logger.debug("Response: " + str(response))
+            output_file_path = os.path.join(CHEMSCRAPER_OUTPUT_DIR, 'chemscraper-output.json')
+            write_json_output(output_file_path=output_file_path)
+        else:
+            # Raise error status if no response body
+            response.raise_for_status()
     except Exception as ex:
         logger.error(f'ERROR: {ex}')
         sys.exit(1)

--- a/run_chemscraper.py
+++ b/run_chemscraper.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import requests
+import sys
 from typing import BinaryIO
 from io import BytesIO
 
@@ -29,7 +30,7 @@ CHEMSCRAPER_OUTPUT_DIR = os.environ.get('CHEMSCRAPER_OUTPUT_DIR', '/workspace/ex
 CHEMSCRAPER_INDEX_NAME = os.environ.get('CHEMSCRAPER_INDEX_NAME', os.environ.get('JOB_ID'))
 
 # Base URL to ChemScraper API
-CHEMSCRAPER_BASE_URL = os.environ.get('CHEMSCRAPER_BASE_URL', 'http://chemscraper-service-staging.staging.svc.cluster.local:8000')
+CHEMSCRAPER_BASE_URL = os.environ.get('CHEMSCRAPER_BASE_URL', 'http://chemscraper-services-staging.staging.svc.cluster.local:8000')
 
 # Read PDFs + locate matching JSONs from disk
 def locate_matching_files(pdf_input_dir):
@@ -104,6 +105,7 @@ def submit_to_chemscraper(index_name, pdf_files, json_files, mapping):
             logger.debug("Response: " + str(response))
     except Exception as ex:
         logger.error(f'ERROR: {ex}')
+        sys.exit(1)
 
 # TODO: Read large files in chunks?
 def read_file_bytes(path) -> BinaryIO:


### PR DESCRIPTION
## Problem
When ReactionMiner job completes, we would like to submit the PDF + JSON files over to ChemScraper

## Approach
* feat: use [openapi-python-client](https://github.com/openapi-generators/openapi-python-client) to generate a Python API client for ChemScraper
* feat: write a new Python script that will call `/index_pdfs_reactions_batch` with PDF + JSON + CSV inputs using API client

## How to Test
This is currently deployed to [mmli-backend-staging](https://argocd.devops.ncsa.illinois.edu/applications/mmli-backend-staging)

1. Navigate to https://mmli.fastapi.staging.mmli1.ncsa.illinois.edu/docs#/Files/upload_file__bucket_name__upload_post
2. Choose a unique `job_id` (or leave it blank to automatically generate one) and upload one or more PDF files to the `reactionminer` bucket: e.g. [copper_acetate.pdf](https://github.com/user-attachments/files/19122175/copper_acetate.pdf)
    * Use the same `job_id` for all uploads
    * Save this `job_id` - we will need this later!
3. Navigate to https://mmli.fastapi.staging.mmli1.ncsa.illinois.edu/docs#/Jobs/create_job__job_type__jobs_post
4. Choose the `reactionminer` and submit a body using the same `job_id` from step 2
    * You should see that a new job with the chosen ID is created in the `staging` namespace on the cluster
5. View the logs for the pre-job: `kubectl logs -f job/mmli-job-reactionminer-<job_id> -n staging -c init`
    * You should see output indicating the input files were downloaded successfully from MinIO
6. View the logs for the running job: `kubectl logs -f job/mmli-job-reactionminer-<job_id> -n staging -c job`
    * You should see that the job runs `pdf2text`
    * Once `pdf2text` is finished, you should see that `ReactionMiner` runs in 3 stages
    * Finally, after ReactionMiner is complete you should see the PDF and JSON files are submitted to the ChemScraper API (staging)
7. View the logs for the ChemScraper API: `kubectl logs -f deploy/chemscraper-services-staging -n staging -c chemscraper`
    * You should see output as ChemScraper runs its various subsystems against the PDF + JSON input: YOLO / SYMBOLSCRAPER / LGAP / etc
8. View the logs for the post-job: `kubectl logs -f job/mmli-job-reactionminer-<job_id> -n staging -c post-job`
    * You should see output indicating the output files were uploaded successfully to MinIO
9. Log into MinIO and browse the `reactionminer` bucket for the folder matching the `job_id`
    * You should see the job output has been uploaded to MinIO and can be fetched by the frontend for visualization
    * You should see `*.json` matching your input PDFs - this is the intermediate output from ReactionMiner
    * You should see `mapping.csv` - this is the PDF->JSON file mapping that was built up as part of this job
    * You should see `chemscraper-output.json` - this is the JSON response returned by ChemScraper
10. Navigate to https://mmli.fastapi.staging.mmli1.ncsa.illinois.edu/docs#/Files/get_results__bucket_name__results__job_id__get
11. Click Try It Now! Enter `bucket_name=reactionminer` and use your same `job_id` as before and click Execute
    * You should see that a map is returned of all result files and their contents - we can use this to visualize the results in the UI